### PR TITLE
Rename tree_ware package to treeWare

### DIFF
--- a/src/main/kotlin/org/treeWare/server/common/TreeWareServer.kt
+++ b/src/main/kotlin/org/treeWare/server/common/TreeWareServer.kt
@@ -1,20 +1,20 @@
-package org.tree_ware.server.common
+package org.treeWare.server.common
 
 import com.datastax.oss.driver.api.core.CqlSession
 import kotlinx.coroutines.runBlocking
 import org.apache.logging.log4j.LogManager
-import org.tree_ware.cassandra.db.GetVisitorDelegate
-import org.tree_ware.cassandra.db.encodeCreateDbSchema
-import org.tree_ware.cassandra.db.encodeDbModel
-import org.tree_ware.cassandra.schema.map.DbSchemaMapAux
-import org.tree_ware.cassandra.schema.map.MutableSchemaMap
-import org.tree_ware.cassandra.schema.map.asModel
-import org.tree_ware.cassandra.util.executeQueries
-import org.tree_ware.model.action.CompositionTableGetVisitor
-import org.tree_ware.model.codec.decodeJson
-import org.tree_ware.model.codec.encodeJson
-import org.tree_ware.model.core.MutableModel
-import org.tree_ware.schema.core.MutableSchema
+import org.treeWare.cassandra.db.GetVisitorDelegate
+import org.treeWare.cassandra.db.encodeCreateDbSchema
+import org.treeWare.cassandra.db.encodeDbModel
+import org.treeWare.cassandra.schema.map.DbSchemaMapAux
+import org.treeWare.cassandra.schema.map.MutableSchemaMap
+import org.treeWare.cassandra.schema.map.asModel
+import org.treeWare.cassandra.util.executeQueries
+import org.treeWare.model.action.CompositionTableGetVisitor
+import org.treeWare.model.codec.decodeJson
+import org.treeWare.model.codec.encodeJson
+import org.treeWare.model.core.MutableModel
+import org.treeWare.schema.core.MutableSchema
 import java.io.Reader
 import java.io.Writer
 
@@ -32,7 +32,7 @@ class TreeWareServer(
 
     // Validate the schema.
     init {
-        val schemaErrors = org.tree_ware.schema.core.validate(schema, logSchemaFullNames)
+        val schemaErrors = org.treeWare.schema.core.validate(schema, logSchemaFullNames)
         isValidSchema = schemaErrors.isEmpty()
         if (schemaErrors.isNotEmpty()) {
             schemaErrors.forEach { logger.error(it) }
@@ -41,7 +41,7 @@ class TreeWareServer(
 
     // Validate the schema-map.
     init {
-        val schemaMapErrors = org.tree_ware.cassandra.schema.map.validate(schemaMap)
+        val schemaMapErrors = org.treeWare.cassandra.schema.map.validate(schemaMap)
         isValidSchemaMap = schemaMapErrors.isEmpty()
         if (schemaMapErrors.isNotEmpty()) {
             schemaMapErrors.forEach { logger.error(it) }
@@ -76,7 +76,7 @@ class TreeWareServer(
         val getRequest = decodeJson<Unit>(request, schema, "data") { null } ?: return
         val delegate = GetVisitorDelegate(cqlSession)
         val visitor = CompositionTableGetVisitor(delegate)
-        val getResponse = org.tree_ware.model.action.get(getRequest, schemaMapModel, visitor)
+        val getResponse = org.treeWare.model.action.get(getRequest, schemaMapModel, visitor)
         // TODO(deepak-nulu): prettyPrint value from URL query-param
         encodeJson(getResponse, null, response, true)
     }

--- a/src/main/kotlin/org/treeWare/server/ktor/CommonModule.kt
+++ b/src/main/kotlin/org/treeWare/server/ktor/CommonModule.kt
@@ -1,4 +1,4 @@
-package org.tree_ware.server.ktor
+package org.treeWare.server.ktor
 
 import io.ktor.application.Application
 import io.ktor.application.call

--- a/src/main/kotlin/org/treeWare/server/ktor/TreeWareModule.kt
+++ b/src/main/kotlin/org/treeWare/server/ktor/TreeWareModule.kt
@@ -1,13 +1,13 @@
-package org.tree_ware.server.ktor
+package org.treeWare.server.ktor
 
 import com.datastax.oss.driver.api.core.CqlSession
 import io.ktor.application.*
 import io.ktor.request.*
 import io.ktor.response.*
 import io.ktor.routing.*
-import org.tree_ware.cassandra.schema.map.MutableSchemaMap
-import org.tree_ware.schema.core.MutableSchema
-import org.tree_ware.server.common.TreeWareServer
+import org.treeWare.cassandra.schema.map.MutableSchemaMap
+import org.treeWare.schema.core.MutableSchema
+import org.treeWare.server.common.TreeWareServer
 import java.io.InputStreamReader
 
 fun Application.treeWareModule(

--- a/src/test/kotlin/org/treeWare/server/ktor/CommonModuleTests.kt
+++ b/src/test/kotlin/org/treeWare/server/ktor/CommonModuleTests.kt
@@ -1,4 +1,4 @@
-package org.tree_ware.server.ktor
+package org.treeWare.server.ktor
 
 import io.ktor.application.Application
 import io.ktor.http.HttpMethod

--- a/src/test/kotlin/org/treeWare/server/ktor/TreeWareModuleDbSchemaTests.kt
+++ b/src/test/kotlin/org/treeWare/server/ktor/TreeWareModuleDbSchemaTests.kt
@@ -1,10 +1,10 @@
-package org.tree_ware.server.ktor
+package org.treeWare.server.ktor
 
 import com.datastax.oss.driver.api.core.CqlSession
 import io.ktor.server.testing.withTestApplication
 import org.cassandraunit.utils.EmbeddedCassandraServerHelper
-import org.tree_ware.cassandra.schema.map.newAddressBookSchema
-import org.tree_ware.cassandra.schema.map.newAddressBookSchemaMap
+import org.treeWare.cassandra.schema.map.newAddressBookSchema
+import org.treeWare.cassandra.schema.map.newAddressBookSchemaMap
 import kotlin.test.Test
 
 class TreeWareModuleDbSchemaTests {

--- a/src/test/kotlin/org/treeWare/server/ktor/TreeWareModuleEchoTests.kt
+++ b/src/test/kotlin/org/treeWare/server/ktor/TreeWareModuleEchoTests.kt
@@ -1,4 +1,4 @@
-package org.tree_ware.server.ktor
+package org.treeWare.server.ktor
 
 import com.datastax.oss.driver.api.core.CqlSession
 import io.ktor.http.HttpMethod
@@ -7,9 +7,9 @@ import io.ktor.server.testing.handleRequest
 import io.ktor.server.testing.setBody
 import io.ktor.server.testing.withTestApplication
 import org.cassandraunit.utils.EmbeddedCassandraServerHelper
-import org.tree_ware.cassandra.schema.map.newAddressBookSchema
-import org.tree_ware.cassandra.schema.map.newAddressBookSchemaMap
-import org.tree_ware.model.getFileReader
+import org.treeWare.cassandra.schema.map.newAddressBookSchema
+import org.treeWare.cassandra.schema.map.newAddressBookSchemaMap
+import org.treeWare.model.getFileReader
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull

--- a/src/test/kotlin/org/treeWare/server/ktor/TreeWareModuleGetTests.kt
+++ b/src/test/kotlin/org/treeWare/server/ktor/TreeWareModuleGetTests.kt
@@ -1,4 +1,4 @@
-package org.tree_ware.server.ktor
+package org.treeWare.server.ktor
 
 import com.datastax.oss.driver.api.core.CqlSession
 import io.ktor.http.*
@@ -6,9 +6,9 @@ import io.ktor.server.testing.*
 import org.cassandraunit.CQLDataLoader
 import org.cassandraunit.dataset.cql.ClassPathCQLDataSet
 import org.cassandraunit.utils.EmbeddedCassandraServerHelper
-import org.tree_ware.cassandra.schema.map.newAddressBookSchema
-import org.tree_ware.cassandra.schema.map.newAddressBookSchemaMap
-import org.tree_ware.model.readFile
+import org.treeWare.cassandra.schema.map.newAddressBookSchema
+import org.treeWare.cassandra.schema.map.newAddressBookSchemaMap
+import org.treeWare.model.readFile
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/src/test/kotlin/org/treeWare/server/ktor/TreeWareModuleSetTests.kt
+++ b/src/test/kotlin/org/treeWare/server/ktor/TreeWareModuleSetTests.kt
@@ -1,12 +1,12 @@
-package org.tree_ware.server.ktor
+package org.treeWare.server.ktor
 
 import com.datastax.oss.driver.api.core.CqlSession
 import io.ktor.http.*
 import io.ktor.server.testing.*
 import org.cassandraunit.utils.EmbeddedCassandraServerHelper
-import org.tree_ware.cassandra.schema.map.newAddressBookSchema
-import org.tree_ware.cassandra.schema.map.newAddressBookSchemaMap
-import org.tree_ware.model.readFile
+import org.treeWare.cassandra.schema.map.newAddressBookSchema
+import org.treeWare.cassandra.schema.map.newAddressBookSchemaMap
+import org.treeWare.model.readFile
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/src/test/kotlin/org/treeWare/server/ktor/VerifyDbContents.kt
+++ b/src/test/kotlin/org/treeWare/server/ktor/VerifyDbContents.kt
@@ -1,8 +1,8 @@
-package org.tree_ware.server.ktor
+package org.treeWare.server.ktor
 
 import com.datastax.oss.driver.api.core.CqlSession
 import com.datastax.oss.driver.api.core.cql.ResultSet
-import org.tree_ware.model.getFileReader
+import org.treeWare.model.getFileReader
 import java.io.StringWriter
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull

--- a/src/test/resources/log4j2.xml
+++ b/src/test/resources/log4j2.xml
@@ -9,7 +9,7 @@
         <Root level="warn">
             <AppenderRef ref="Console"/>
         </Root>
-        <Logger name="org.tree_ware" level="debug" additivity="false">
+        <Logger name="org.treeWare" level="debug" additivity="false">
             <AppenderRef ref="Console"/>
         </Logger>
     </Loggers>


### PR DESCRIPTION
The Kotlin style guide recommends the use of camelCase instead of
snake_case for multi-word package names.