### PR TITLE
Set the hasher to null in the server

### DIFF
--- a/src/main/kotlin/org/treeWare/server/common/TreeWareServer.kt
+++ b/src/main/kotlin/org/treeWare/server/common/TreeWareServer.kt
@@ -5,7 +5,6 @@ import org.treeWare.metaModel.getMetaName
 import org.treeWare.metaModel.getRootMeta
 import org.treeWare.metaModel.newMainMetaMetaModel
 import org.treeWare.metaModel.validation.validate
-import org.treeWare.model.core.HasherV1
 import org.treeWare.model.core.MainModel
 import org.treeWare.model.core.Resolved
 import org.treeWare.model.decoder.decodeJson
@@ -24,7 +23,7 @@ class TreeWareServer(
 
     private val logger = LogManager.getLogger()
     private val metaModel: MainModel<Resolved>
-    private val hasher = HasherV1()
+    private val hasher = null // TODO(deepak-nulu): create a hasher based on server configuration.
     private val cipher = null // TODO(deepak-nulu): get a secret key from server configuration and create a cipher.
 
     // Validate the meta-model.


### PR DESCRIPTION
The test file from the core repo now has passwords and secrets in it.
To make the server echo test pass, the server under test needs to use
a null hasher. The hasher is currently not configurable in the server
so it is set to null in this commit. Eventually, the hasher (and the
cipher) will be configurable so that a real hasher (and cipher) can be
used in production, with a null hasher (and cipher) used only in the
tests.